### PR TITLE
Fix dependencies in scale courses.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.57"
 indoc = "1.0"
-trane = "0.2.7"
+trane = "0.2.8"
 
 # Commented out for use for local development.
 # trane = { path = "../trane" }

--- a/courses/major_pentatonic_scale/basics/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/basics/lesson_manifest.json
@@ -1,6 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::basics",
-  "dependencies": [],
+  "dependencies": [
+    "trane::music::theory::major_scale::basics"
+  ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Basic Construction",
   "description": "Learn the intervals which make up the major pentatonic scale.",

--- a/courses/major_pentatonic_scale/course_manifest.json
+++ b/courses/major_pentatonic_scale/course_manifest.json
@@ -1,9 +1,7 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale",
   "name": "The Major Pentatonic Scale",
-  "dependencies": [
-    "trane::music::theory::major_scale"
-  ],
+  "dependencies": [],
   "description": "Learn the notes of the major pentatonic scale for all twelve keys",
   "authors": [
     "The Trane Project"

--- a/courses/major_pentatonic_scale/lesson_A/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_A/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::A",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::D"
+    "trane::music::theory::major_pentatonic_scale::D",
+    "trane::music::theory::major_scale::A"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of A",

--- a/courses/major_pentatonic_scale/lesson_A_flat/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_A_flat/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::A♭",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::E♭"
+    "trane::music::theory::major_pentatonic_scale::E♭",
+    "trane::music::theory::major_scale::A♭"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of A♭",

--- a/courses/major_pentatonic_scale/lesson_B/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_B/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::B",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::E"
+    "trane::music::theory::major_pentatonic_scale::E",
+    "trane::music::theory::major_scale::B"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of B",

--- a/courses/major_pentatonic_scale/lesson_B_flat/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_B_flat/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::B♭",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::F"
+    "trane::music::theory::major_pentatonic_scale::F",
+    "trane::music::theory::major_scale::B♭"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of B♭",

--- a/courses/major_pentatonic_scale/lesson_C/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_C/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::C",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::basics"
+    "trane::music::theory::major_pentatonic_scale::basics",
+    "trane::music::theory::major_scale::C"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of C",

--- a/courses/major_pentatonic_scale/lesson_C_flat/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_C_flat/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::C♭",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::G♭"
+    "trane::music::theory::major_pentatonic_scale::G♭",
+    "trane::music::theory::major_scale::C♭"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of C♭",

--- a/courses/major_pentatonic_scale/lesson_C_sharp/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_C_sharp/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::C♯",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::F♯"
+    "trane::music::theory::major_pentatonic_scale::F♯",
+    "trane::music::theory::major_scale::C♯"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of C♯",

--- a/courses/major_pentatonic_scale/lesson_D/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_D/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::D",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::G"
+    "trane::music::theory::major_pentatonic_scale::G",
+    "trane::music::theory::major_scale::D"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of D",

--- a/courses/major_pentatonic_scale/lesson_D_flat/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_D_flat/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::D♭",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::A♭"
+    "trane::music::theory::major_pentatonic_scale::A♭",
+    "trane::music::theory::major_scale::D♭"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of D♭",

--- a/courses/major_pentatonic_scale/lesson_E/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_E/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::E",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::A"
+    "trane::music::theory::major_pentatonic_scale::A",
+    "trane::music::theory::major_scale::E"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of E",

--- a/courses/major_pentatonic_scale/lesson_E_flat/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_E_flat/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::E♭",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::B♭"
+    "trane::music::theory::major_pentatonic_scale::B♭",
+    "trane::music::theory::major_scale::E♭"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of E♭",

--- a/courses/major_pentatonic_scale/lesson_F/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_F/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::F",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::C"
+    "trane::music::theory::major_pentatonic_scale::C",
+    "trane::music::theory::major_scale::F"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of F",

--- a/courses/major_pentatonic_scale/lesson_F_sharp/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_F_sharp/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::F♯",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::B"
+    "trane::music::theory::major_pentatonic_scale::B",
+    "trane::music::theory::major_scale::F♯"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of F♯",

--- a/courses/major_pentatonic_scale/lesson_G/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_G/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::G",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::C"
+    "trane::music::theory::major_pentatonic_scale::C",
+    "trane::music::theory::major_scale::G"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of G",

--- a/courses/major_pentatonic_scale/lesson_G_flat/lesson_manifest.json
+++ b/courses/major_pentatonic_scale/lesson_G_flat/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::major_pentatonic_scale::G♭",
   "dependencies": [
-    "trane::music::theory::major_pentatonic_scale::D♭"
+    "trane::music::theory::major_pentatonic_scale::D♭",
+    "trane::music::theory::major_scale::G♭"
   ],
   "course_id": "trane::music::theory::major_pentatonic_scale",
   "name": "Major Pentatonic Scale - Key of G♭",

--- a/courses/minor_pentatonic_scale/basics/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/basics/lesson_manifest.json
@@ -1,6 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::basics",
-  "dependencies": [],
+  "dependencies": [
+    "trane::music::theory::minor_scale::basics"
+  ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Basic Construction",
   "description": "Learn the intervals which make up the minor pentatonic scale.",

--- a/courses/minor_pentatonic_scale/course_manifest.json
+++ b/courses/minor_pentatonic_scale/course_manifest.json
@@ -1,9 +1,7 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale",
   "name": "The Minor Pentatonic Scale",
-  "dependencies": [
-    "trane::music::theory::minor_scale"
-  ],
+  "dependencies": [],
   "description": "Learn the notes of the minor pentatonic scale for all twelve keys",
   "authors": [
     "The Trane Project"

--- a/courses/minor_pentatonic_scale/lesson_A/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_A/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::A",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::basics"
+    "trane::music::theory::minor_pentatonic_scale::basics",
+    "trane::music::theory::minor_scale::A"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of A",

--- a/courses/minor_pentatonic_scale/lesson_A_flat/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_A_flat/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::A♭",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::E♭"
+    "trane::music::theory::minor_pentatonic_scale::E♭",
+    "trane::music::theory::minor_scale::A♭"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of A♭",

--- a/courses/minor_pentatonic_scale/lesson_A_sharp/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_A_sharp/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::A♯",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::D♯"
+    "trane::music::theory::minor_pentatonic_scale::D♯",
+    "trane::music::theory::minor_scale::A♯"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of A♯",

--- a/courses/minor_pentatonic_scale/lesson_B/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_B/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::B",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::E"
+    "trane::music::theory::minor_pentatonic_scale::E",
+    "trane::music::theory::minor_scale::B"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of B",

--- a/courses/minor_pentatonic_scale/lesson_B_flat/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_B_flat/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::B♭",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::F"
+    "trane::music::theory::minor_pentatonic_scale::F",
+    "trane::music::theory::minor_scale::B♭"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of B♭",

--- a/courses/minor_pentatonic_scale/lesson_C/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_C/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::C",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::G"
+    "trane::music::theory::minor_pentatonic_scale::G",
+    "trane::music::theory::minor_scale::C"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of C",

--- a/courses/minor_pentatonic_scale/lesson_C_sharp/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_C_sharp/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::C♯",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::F♯"
+    "trane::music::theory::minor_pentatonic_scale::F♯",
+    "trane::music::theory::minor_scale::C♯"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of C♯",

--- a/courses/minor_pentatonic_scale/lesson_D/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_D/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::D",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::A"
+    "trane::music::theory::minor_pentatonic_scale::A",
+    "trane::music::theory::minor_scale::D"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of D",

--- a/courses/minor_pentatonic_scale/lesson_D_sharp/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_D_sharp/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::D♯",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::G♯"
+    "trane::music::theory::minor_pentatonic_scale::G♯",
+    "trane::music::theory::minor_scale::D♯"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of D♯",

--- a/courses/minor_pentatonic_scale/lesson_E/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_E/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::E",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::A"
+    "trane::music::theory::minor_pentatonic_scale::A",
+    "trane::music::theory::minor_scale::E"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of E",

--- a/courses/minor_pentatonic_scale/lesson_E_flat/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_E_flat/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::E♭",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::B♭"
+    "trane::music::theory::minor_pentatonic_scale::B♭",
+    "trane::music::theory::minor_scale::E♭"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of E♭",

--- a/courses/minor_pentatonic_scale/lesson_F/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_F/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::F",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::C"
+    "trane::music::theory::minor_pentatonic_scale::C",
+    "trane::music::theory::minor_scale::F"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of F",

--- a/courses/minor_pentatonic_scale/lesson_F_sharp/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_F_sharp/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::F♯",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::B"
+    "trane::music::theory::minor_pentatonic_scale::B",
+    "trane::music::theory::minor_scale::F♯"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of F♯",

--- a/courses/minor_pentatonic_scale/lesson_G/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_G/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::G",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::D"
+    "trane::music::theory::minor_pentatonic_scale::D",
+    "trane::music::theory::minor_scale::G"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of G",

--- a/courses/minor_pentatonic_scale/lesson_G_sharp/lesson_manifest.json
+++ b/courses/minor_pentatonic_scale/lesson_G_sharp/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_pentatonic_scale::G♯",
   "dependencies": [
-    "trane::music::theory::minor_pentatonic_scale::C♯"
+    "trane::music::theory::minor_pentatonic_scale::C♯",
+    "trane::music::theory::minor_scale::G♯"
   ],
   "course_id": "trane::music::theory::minor_pentatonic_scale",
   "name": "Minor Pentatonic Scale - Key of G♯",

--- a/courses/minor_scale/basics/lesson_manifest.json
+++ b/courses/minor_scale/basics/lesson_manifest.json
@@ -1,6 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::basics",
-  "dependencies": [],
+  "dependencies": [
+    "trane::music::theory::major_scale::basics"
+  ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Basic Construction",
   "description": "Learn the intervals which make up the minor scale.",

--- a/courses/minor_scale/course_manifest.json
+++ b/courses/minor_scale/course_manifest.json
@@ -1,9 +1,7 @@
 {
   "id": "trane::music::theory::minor_scale",
   "name": "The Minor Scale",
-  "dependencies": [
-    "trane::music::theory::major_scale"
-  ],
+  "dependencies": [],
   "description": "Learn the notes of the minor scale for all twelve keys",
   "authors": [
     "The Trane Project"

--- a/courses/minor_scale/lesson_A/lesson_manifest.json
+++ b/courses/minor_scale/lesson_A/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::A",
   "dependencies": [
-    "trane::music::theory::minor_scale::basics"
+    "trane::music::theory::minor_scale::basics",
+    "trane::music::theory::major_scale::C"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of A",

--- a/courses/minor_scale/lesson_A_flat/lesson_manifest.json
+++ b/courses/minor_scale/lesson_A_flat/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::A♭",
   "dependencies": [
-    "trane::music::theory::minor_scale::E♭"
+    "trane::music::theory::minor_scale::E♭",
+    "trane::music::theory::major_scale::C♭"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of A♭",

--- a/courses/minor_scale/lesson_A_sharp/lesson_manifest.json
+++ b/courses/minor_scale/lesson_A_sharp/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::A♯",
   "dependencies": [
-    "trane::music::theory::minor_scale::D♯"
+    "trane::music::theory::minor_scale::D♯",
+    "trane::music::theory::major_scale::C♯"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of A♯",

--- a/courses/minor_scale/lesson_B/lesson_manifest.json
+++ b/courses/minor_scale/lesson_B/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::B",
   "dependencies": [
-    "trane::music::theory::minor_scale::E"
+    "trane::music::theory::minor_scale::E",
+    "trane::music::theory::major_scale::D"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of B",

--- a/courses/minor_scale/lesson_B_flat/lesson_manifest.json
+++ b/courses/minor_scale/lesson_B_flat/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::B♭",
   "dependencies": [
-    "trane::music::theory::minor_scale::F"
+    "trane::music::theory::minor_scale::F",
+    "trane::music::theory::major_scale::D♭"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of B♭",

--- a/courses/minor_scale/lesson_C/lesson_manifest.json
+++ b/courses/minor_scale/lesson_C/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::C",
   "dependencies": [
-    "trane::music::theory::minor_scale::G"
+    "trane::music::theory::minor_scale::G",
+    "trane::music::theory::major_scale::E♭"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of C",

--- a/courses/minor_scale/lesson_C_sharp/lesson_manifest.json
+++ b/courses/minor_scale/lesson_C_sharp/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::C♯",
   "dependencies": [
-    "trane::music::theory::minor_scale::F♯"
+    "trane::music::theory::minor_scale::F♯",
+    "trane::music::theory::major_scale::E"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of C♯",

--- a/courses/minor_scale/lesson_D/lesson_manifest.json
+++ b/courses/minor_scale/lesson_D/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::D",
   "dependencies": [
-    "trane::music::theory::minor_scale::A"
+    "trane::music::theory::minor_scale::A",
+    "trane::music::theory::major_scale::F"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of D",

--- a/courses/minor_scale/lesson_D_sharp/lesson_manifest.json
+++ b/courses/minor_scale/lesson_D_sharp/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::D♯",
   "dependencies": [
-    "trane::music::theory::minor_scale::G♯"
+    "trane::music::theory::minor_scale::G♯",
+    "trane::music::theory::major_scale::F♯"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of D♯",

--- a/courses/minor_scale/lesson_E/lesson_manifest.json
+++ b/courses/minor_scale/lesson_E/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::E",
   "dependencies": [
-    "trane::music::theory::minor_scale::A"
+    "trane::music::theory::minor_scale::A",
+    "trane::music::theory::major_scale::G"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of E",

--- a/courses/minor_scale/lesson_E_flat/lesson_manifest.json
+++ b/courses/minor_scale/lesson_E_flat/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::E♭",
   "dependencies": [
-    "trane::music::theory::minor_scale::B♭"
+    "trane::music::theory::minor_scale::B♭",
+    "trane::music::theory::major_scale::G♭"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of E♭",

--- a/courses/minor_scale/lesson_F/lesson_manifest.json
+++ b/courses/minor_scale/lesson_F/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::F",
   "dependencies": [
-    "trane::music::theory::minor_scale::C"
+    "trane::music::theory::minor_scale::C",
+    "trane::music::theory::major_scale::A♭"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of F",

--- a/courses/minor_scale/lesson_F_sharp/lesson_manifest.json
+++ b/courses/minor_scale/lesson_F_sharp/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::F♯",
   "dependencies": [
-    "trane::music::theory::minor_scale::B"
+    "trane::music::theory::minor_scale::B",
+    "trane::music::theory::major_scale::A"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of F♯",

--- a/courses/minor_scale/lesson_G/lesson_manifest.json
+++ b/courses/minor_scale/lesson_G/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::G",
   "dependencies": [
-    "trane::music::theory::minor_scale::D"
+    "trane::music::theory::minor_scale::D",
+    "trane::music::theory::major_scale::B♭"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of G",

--- a/courses/minor_scale/lesson_G_sharp/lesson_manifest.json
+++ b/courses/minor_scale/lesson_G_sharp/lesson_manifest.json
@@ -1,7 +1,8 @@
 {
   "id": "trane::music::theory::minor_scale::G♯",
   "dependencies": [
-    "trane::music::theory::minor_scale::C♯"
+    "trane::music::theory::minor_scale::C♯",
+    "trane::music::theory::major_scale::B"
   ],
   "course_id": "trane::music::theory::minor_scale",
   "name": "Minor Scale - Key of G♯",

--- a/src/theory/major_pentatonic_scale.rs
+++ b/src/theory/major_pentatonic_scale.rs
@@ -118,7 +118,7 @@ fn generate_basics_lesson() -> Result<LessonBuilder> {
                 .description(Some(
                     "Learn the intervals which make up the major pentatonic scale.".to_string(),
                 ))
-                .dependencies(vec![])
+                .dependencies(vec![format!("{}::basics", major_scale::COURSE_ID)])
                 .clone()
         }),
     })
@@ -130,7 +130,7 @@ pub fn course_builder() -> Result<CourseBuilder> {
         course_manifest: CourseManifest {
             id: COURSE_ID.to_string(),
             name: "The Major Pentatonic Scale".to_string(),
-            dependencies: vec![major_scale::COURSE_ID.to_string()],
+            dependencies: vec![],
             description: Some(
                 "Learn the notes of the major pentatonic scale for all twelve keys".to_string(),
             ),
@@ -171,11 +171,12 @@ pub fn course_builder() -> Result<CourseBuilder> {
                 asset_builders: vec![],
                 exercise_builders: generate_exercise_builders(note)?,
                 manifest_closure: Box::new(move |m| {
+                    let major_id = format!("{}::{}", major_scale::COURSE_ID, note.to_string());
                     let deps = match previous_note {
-                        None => vec![format!("{}::basics", COURSE_ID)],
+                        None => vec![format!("{}::basics", COURSE_ID), major_id],
                         Some(previous_note) => {
                             let dep_id = format!("{}::{}", COURSE_ID, previous_note.to_string());
-                            vec![dep_id]
+                            vec![dep_id, major_id]
                         }
                     };
 

--- a/src/theory/minor_pentatonic_scale.rs
+++ b/src/theory/minor_pentatonic_scale.rs
@@ -118,7 +118,7 @@ fn generate_basics_lesson() -> Result<LessonBuilder> {
                 .description(Some(
                     "Learn the intervals which make up the minor pentatonic scale.".to_string(),
                 ))
-                .dependencies(vec![])
+                .dependencies(vec![format!("{}::basics", minor_scale::COURSE_ID)])
                 .clone()
         }),
     })
@@ -130,7 +130,7 @@ pub fn course_builder() -> Result<CourseBuilder> {
         course_manifest: CourseManifest {
             id: COURSE_ID.to_string(),
             name: "The Minor Pentatonic Scale".to_string(),
-            dependencies: vec![minor_scale::COURSE_ID.to_string()],
+            dependencies: vec![],
             description: Some(
                 "Learn the notes of the minor pentatonic scale for all twelve keys".to_string(),
             ),
@@ -171,11 +171,13 @@ pub fn course_builder() -> Result<CourseBuilder> {
                 asset_builders: vec![],
                 exercise_builders: generate_exercise_builders(note)?,
                 manifest_closure: Box::new(move |m| {
+                    let minor_id =
+                        format!("{}::{}", minor_scale::COURSE_ID, note.to_string());
                     let deps = match previous_note {
-                        None => vec![format!("{}::basics", COURSE_ID)],
+                        None => vec![format!("{}::basics", COURSE_ID), minor_id],
                         Some(previous_note) => {
                             let dep_id = format!("{}::{}", COURSE_ID, previous_note.to_string());
-                            vec![dep_id]
+                            vec![dep_id, minor_id]
                         }
                     };
 

--- a/src/theory/minor_pentatonic_scale.rs
+++ b/src/theory/minor_pentatonic_scale.rs
@@ -171,8 +171,7 @@ pub fn course_builder() -> Result<CourseBuilder> {
                 asset_builders: vec![],
                 exercise_builders: generate_exercise_builders(note)?,
                 manifest_closure: Box::new(move |m| {
-                    let minor_id =
-                        format!("{}::{}", minor_scale::COURSE_ID, note.to_string());
+                    let minor_id = format!("{}::{}", minor_scale::COURSE_ID, note.to_string());
                     let deps = match previous_note {
                         None => vec![format!("{}::basics", COURSE_ID), minor_id],
                         Some(previous_note) => {

--- a/src/theory/minor_scale.rs
+++ b/src/theory/minor_scale.rs
@@ -118,7 +118,7 @@ fn generate_basics_lesson() -> Result<LessonBuilder> {
                 .description(Some(
                     "Learn the intervals which make up the minor scale.".to_string(),
                 ))
-                .dependencies(vec![])
+                .dependencies(vec![format!("{}::basics", major_scale::COURSE_ID)])
                 .clone()
         }),
     })
@@ -130,7 +130,7 @@ pub fn course_builder() -> Result<CourseBuilder> {
         course_manifest: CourseManifest {
             id: COURSE_ID.to_string(),
             name: "The Minor Scale".to_string(),
-            dependencies: vec![major_scale::COURSE_ID.to_string()],
+            dependencies: vec![],
             description: Some("Learn the notes of the minor scale for all twelve keys".to_string()),
             authors: Some(vec![AUTHORS.to_string()]),
             metadata: Some(BTreeMap::from([
@@ -169,11 +169,16 @@ pub fn course_builder() -> Result<CourseBuilder> {
                 asset_builders: vec![],
                 exercise_builders: generate_exercise_builders(note)?,
                 manifest_closure: Box::new(move |m| {
+                    let major_id = format!(
+                        "{}::{}",
+                        major_scale::COURSE_ID,
+                        note.relative_major().unwrap().to_string()
+                    );
                     let deps = match previous_note {
-                        None => vec![format!("{}::basics", COURSE_ID)],
+                        None => vec![format!("{}::basics", COURSE_ID), major_id],
                         Some(previous_note) => {
                             let dep_id = format!("{}::{}", COURSE_ID, previous_note.to_string());
-                            vec![dep_id]
+                            vec![dep_id, major_id]
                         }
                     };
 


### PR DESCRIPTION
The scale courses should not depend on an entire course but each
lesson should depend on another lesson. For example, the lesson on
A minor depends on the lesson on C Major.

This change is meant to allow users to make faster progress through
these courses.